### PR TITLE
Skip Installation if Cache is Found

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -81384,14 +81384,14 @@ async function main() {
         const cacheId = await cache.restoreCache(cachePaths.slice(), cacheKey);
         return cacheId !== undefined;
     });
-    await core.group("Installing dependencies", async () => {
-        // Prevent `yarn install` from outputting group log messages.
-        const env = external_process_namespaceObject.env;
-        env["GITHUB_ACTIONS"] = "";
-        env["FORCE_COLOR"] = "true";
-        return exec.exec("corepack", ["yarn", "install"], { env });
-    });
     if (!cacheFound) {
+        await core.group("Installing dependencies", async () => {
+            // Prevent `yarn install` from outputting group log messages.
+            const env = external_process_namespaceObject.env;
+            env["GITHUB_ACTIONS"] = "";
+            env["FORCE_COLOR"] = "true";
+            return exec.exec("corepack", ["yarn", "install"], { env });
+        });
         await core.group("Saving cache", async () => {
             return cache.saveCache(cachePaths.slice(), cacheKey);
         });

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -81385,6 +81385,15 @@ async function main() {
         return cacheId !== undefined;
     });
     if (!cacheFound) {
+        await core.group("Disabling global cache", async () => {
+            return exec.exec("corepack", [
+                "yarn",
+                "config",
+                "set",
+                "enableGlobalCache",
+                "false",
+            ]);
+        });
         await core.group("Installing dependencies", async () => {
             // Prevent `yarn install` from outputting group log messages.
             const env = external_process_namespaceObject.env;

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -81378,7 +81378,7 @@ async function main() {
     await core.group("Enabling Yarn", async () => {
         return exec.exec("corepack", ["enable", "yarn"]);
     });
-    const cachePaths = [".yarn"];
+    const cachePaths = [".yarn", ".pnp.cjs", ".pnp.loader.mjs"];
     const cacheKey = `yarn-install-action-${external_os_.type()}`;
     const cacheFound = await core.group("Restoring cache", async () => {
         const cacheId = await cache.restoreCache(cachePaths.slice(), cacheKey);

--- a/src/index.mts
+++ b/src/index.mts
@@ -18,6 +18,16 @@ async function main() {
   });
 
   if (!cacheFound) {
+    await core.group("Disabling global cache", async () => {
+      return exec.exec("corepack", [
+        "yarn",
+        "config",
+        "set",
+        "enableGlobalCache",
+        "false",
+      ]);
+    });
+
     await core.group("Installing dependencies", async () => {
       // Prevent `yarn install` from outputting group log messages.
       const env = process.env as { [key: string]: string };

--- a/src/index.mts
+++ b/src/index.mts
@@ -9,7 +9,7 @@ async function main() {
     return exec.exec("corepack", ["enable", "yarn"]);
   });
 
-  const cachePaths = [".yarn"];
+  const cachePaths = [".yarn", ".pnp.cjs", ".pnp.loader.mjs"];
   const cacheKey = `yarn-install-action-${os.type()}`;
 
   const cacheFound = await core.group("Restoring cache", async () => {

--- a/src/index.mts
+++ b/src/index.mts
@@ -17,16 +17,16 @@ async function main() {
     return cacheId !== undefined;
   });
 
-  await core.group("Installing dependencies", async () => {
-    // Prevent `yarn install` from outputting group log messages.
-    const env = process.env as { [key: string]: string };
-    env["GITHUB_ACTIONS"] = "";
-    env["FORCE_COLOR"] = "true";
-
-    return exec.exec("corepack", ["yarn", "install"], { env });
-  });
-
   if (!cacheFound) {
+    await core.group("Installing dependencies", async () => {
+      // Prevent `yarn install` from outputting group log messages.
+      const env = process.env as { [key: string]: string };
+      env["GITHUB_ACTIONS"] = "";
+      env["FORCE_COLOR"] = "true";
+
+      return exec.exec("corepack", ["yarn", "install"], { env });
+    });
+
     await core.group("Saving cache", async () => {
       return cache.saveCache(cachePaths.slice(), cacheKey);
     });

--- a/src/index.mts
+++ b/src/index.mts
@@ -14,33 +14,40 @@ async function main() {
 
   const cacheFound = await core.group("Restoring cache", async () => {
     const cacheId = await cache.restoreCache(cachePaths.slice(), cacheKey);
-    return cacheId !== undefined;
+    if (cacheId === undefined) {
+      core.warning("Cache not found");
+      return false;
+    }
+    return true;
   });
 
-  if (!cacheFound) {
-    await core.group("Disabling global cache", async () => {
-      return exec.exec("corepack", [
-        "yarn",
-        "config",
-        "set",
-        "enableGlobalCache",
-        "false",
-      ]);
-    });
-
-    await core.group("Installing dependencies", async () => {
-      // Prevent `yarn install` from outputting group log messages.
-      const env = process.env as { [key: string]: string };
-      env["GITHUB_ACTIONS"] = "";
-      env["FORCE_COLOR"] = "true";
-
-      return exec.exec("corepack", ["yarn", "install"], { env });
-    });
-
-    await core.group("Saving cache", async () => {
-      return cache.saveCache(cachePaths.slice(), cacheKey);
-    });
+  if (cacheFound) {
+    core.info("Cache restored successfully");
+    return;
   }
+
+  await core.group("Disabling global cache", async () => {
+    return exec.exec("corepack", [
+      "yarn",
+      "config",
+      "set",
+      "enableGlobalCache",
+      "false",
+    ]);
+  });
+
+  await core.group("Installing dependencies", async () => {
+    // Prevent `yarn install` from outputting group log messages.
+    const env = process.env as { [key: string]: string };
+    env["GITHUB_ACTIONS"] = "";
+    env["FORCE_COLOR"] = "true";
+
+    return exec.exec("corepack", ["yarn", "install"], { env });
+  });
+
+  await core.group("Saving cache", async () => {
+    return cache.saveCache(cachePaths.slice(), cacheKey);
+  });
 }
 
 main();


### PR DESCRIPTION
This pull request includes the following changes:

- Adds `.pnp.cjs` and `.pnp.loader.mjs` files to be saved as part of the cache.
- Displays logs indicating whether the cache is found or not found.
- Disables the global cache before installing dependencies to ensure they are installed in the current directory.

It closes #25.