### PR TITLE
Bump Yarn to Version 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,5 @@
     "eslint-plugin-json-files": "^4.1.0",
     "prettier": "^3.2.5"
   },
-  "packageManager": "yarn@4.0.2"
+  "packageManager": "yarn@4.1.0"
 }


### PR DESCRIPTION
This pull request simply bumps Yarn to version [4.1.0](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.1.0).