### PR TITLE
Get Yarn Cache Path From Yarn Config

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -81532,7 +81532,18 @@ async function main() {
     },
   );
 
-  const cachePaths = [".yarn", ".pnp.cjs", ".pnp.loader.mjs"];
+  const cachePaths = [
+    await _yarn_mjs__WEBPACK_IMPORTED_MODULE_4__/* ["default"].getConfig */ .Z.getConfig("cacheFolder"),
+    await _yarn_mjs__WEBPACK_IMPORTED_MODULE_4__/* ["default"].getConfig */ .Z.getConfig("deferredVersionFolder"),
+    await _yarn_mjs__WEBPACK_IMPORTED_MODULE_4__/* ["default"].getConfig */ .Z.getConfig("installStatePath"),
+    await _yarn_mjs__WEBPACK_IMPORTED_MODULE_4__/* ["default"].getConfig */ .Z.getConfig("patchFolder"),
+    await _yarn_mjs__WEBPACK_IMPORTED_MODULE_4__/* ["default"].getConfig */ .Z.getConfig("pnpUnpluggedFolder"),
+    await _yarn_mjs__WEBPACK_IMPORTED_MODULE_4__/* ["default"].getConfig */ .Z.getConfig("virtualFolder"),
+    ".yarn",
+    ".pnp.cjs",
+    ".pnp.loader.mjs",
+  ];
+
   const cacheKey =
     lockFileHash !== undefined
       ? `yarn-install-action-${os__WEBPACK_IMPORTED_MODULE_3__.type()}-${version}-${lockFileHash}`

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -81611,12 +81611,13 @@ async function enable() {
 }
 
 async function getConfig(name) {
-  const prom = await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.getExecOutput)("corepack", [
-    "yarn",
-    "config",
-    name,
-    "--json",
-  ]);
+  const prom = await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.getExecOutput)(
+    "corepack",
+    ["yarn", "config", name, "--json"],
+    {
+      silent: true,
+    },
+  );
   const jsonData = (await prom).stdout;
   return JSON.parse(jsonData).effective;
 }

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -81599,6 +81599,17 @@ async function enable() {
   await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.exec)("corepack", ["enable", "yarn"]);
 }
 
+async function getConfig(name) {
+  const prom = await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.getExecOutput)("corepack", [
+    "yarn",
+    "config",
+    name,
+    "--json",
+  ]);
+  const jsonData = (await prom).stdout;
+  return JSON.parse(jsonData).effective;
+}
+
 async function install() {
   const env = process.env;
 
@@ -81617,7 +81628,7 @@ async function version() {
   return res.stdout.trim();
 }
 
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({ disableGlobalCache, enable, install, version });
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({ disableGlobalCache, enable, getConfig, install, version });
 
 
 /***/ }),

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -29,7 +29,18 @@ async function main() {
     },
   );
 
-  const cachePaths = [".yarn", ".pnp.cjs", ".pnp.loader.mjs"];
+  const cachePaths = [
+    await yarn.getConfig("cacheFolder"),
+    await yarn.getConfig("deferredVersionFolder"),
+    await yarn.getConfig("installStatePath"),
+    await yarn.getConfig("patchFolder"),
+    await yarn.getConfig("pnpUnpluggedFolder"),
+    await yarn.getConfig("virtualFolder"),
+    ".yarn",
+    ".pnp.cjs",
+    ".pnp.loader.mjs",
+  ];
+
   const cacheKey =
     lockFileHash !== undefined
       ? `yarn-install-action-${os.type()}-${version}-${lockFileHash}`

--- a/src/yarn.mjs
+++ b/src/yarn.mjs
@@ -15,12 +15,13 @@ async function enable() {
 }
 
 async function getConfig(name) {
-  const prom = await getExecOutput("corepack", [
-    "yarn",
-    "config",
-    name,
-    "--json",
-  ]);
+  const prom = await getExecOutput(
+    "corepack",
+    ["yarn", "config", name, "--json"],
+    {
+      silent: true,
+    },
+  );
   const jsonData = (await prom).stdout;
   return JSON.parse(jsonData).effective;
 }

--- a/src/yarn.mjs
+++ b/src/yarn.mjs
@@ -14,6 +14,17 @@ async function enable() {
   await exec("corepack", ["enable", "yarn"]);
 }
 
+async function getConfig(name) {
+  const prom = await getExecOutput("corepack", [
+    "yarn",
+    "config",
+    name,
+    "--json",
+  ]);
+  const jsonData = (await prom).stdout;
+  return JSON.parse(jsonData).effective;
+}
+
 async function install() {
   const env = process.env;
 
@@ -32,4 +43,4 @@ async function version() {
   return res.stdout.trim();
 }
 
-export default { disableGlobalCache, enable, install, version };
+export default { disableGlobalCache, enable, getConfig, install, version };

--- a/src/yarn.test.mjs
+++ b/src/yarn.test.mjs
@@ -46,12 +46,13 @@ it("should get Yarn config", async () => {
   const value = await yarn.getConfig("globalFolder");
 
   expect(getExecOutput).toHaveBeenCalledTimes(1);
-  expect(getExecOutput).toHaveBeenCalledWith("corepack", [
-    "yarn",
-    "config",
-    "globalFolder",
-    "--json",
-  ]);
+  expect(getExecOutput).toHaveBeenCalledWith(
+    "corepack",
+    ["yarn", "config", "globalFolder", "--json"],
+    {
+      silent: true,
+    },
+  );
 
   expect(value).toEqual("/.yarn/berry");
 });

--- a/src/yarn.test.mjs
+++ b/src/yarn.test.mjs
@@ -35,6 +35,27 @@ it("should enable Yarn", async () => {
   expect(exec).toHaveBeenCalledWith("corepack", ["enable", "yarn"]);
 });
 
+it("should get Yarn config", async () => {
+  const { getExecOutput } = await import("@actions/exec");
+  const yarn = (await import("./yarn.mjs")).default;
+
+  getExecOutput.mockResolvedValue({
+    stdout: `{"key":"globalFolder","effective":"/.yarn/berry","source":"<default>","description":"Folder where all system-global files are stored","type":"ABSOLUTE_PATH","default":"/.yarn/berry"}\n`,
+  });
+
+  const value = await yarn.getConfig("globalFolder");
+
+  expect(getExecOutput).toHaveBeenCalledTimes(1);
+  expect(getExecOutput).toHaveBeenCalledWith("corepack", [
+    "yarn",
+    "config",
+    "globalFolder",
+    "--json",
+  ]);
+
+  expect(value).toEqual("/.yarn/berry");
+});
+
 it("should install package using Yarn", async () => {
   const { exec } = await import("@actions/exec");
   const yarn = (await import("./yarn.mjs")).default;


### PR DESCRIPTION
This pull request resolves #130 by introducing the following changes:
- Adds a `yarn.getConfig` function alongside its testing.
- Modifies the action to list cache paths based on the value from the Yarn config.