### PR TITLE
Getting Yarn Version Silently

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79625,7 +79625,9 @@ async function install() {
     await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.exec)("corepack", ["yarn", "install"], { env });
 }
 async function version() {
-    const res = await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.getExecOutput)("corepack", ["yarn", "--version"]);
+    const res = await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.getExecOutput)("corepack", ["yarn", "--version"], {
+        silent: true,
+    });
     return res.stdout.trim();
 }
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({ disableGlobalCache, enable, getConfig, install, version });

--- a/src/yarn.test.ts
+++ b/src/yarn.test.ts
@@ -91,10 +91,13 @@ it("should get Yarn version", async () => {
   const version = await yarn.version();
 
   expect(mock.getExecOutput).toHaveBeenCalledTimes(1);
-  expect(mock.getExecOutput).toHaveBeenCalledWith("corepack", [
-    "yarn",
-    "--version",
-  ]);
+  expect(mock.getExecOutput).toHaveBeenCalledWith(
+    "corepack",
+    ["yarn", "--version"],
+    {
+      silent: true,
+    },
+  );
 
   expect(version).toEqual("1.2.3");
 });

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -40,7 +40,9 @@ async function install(): Promise<void> {
 }
 
 async function version() {
-  const res = await getExecOutput("corepack", ["yarn", "--version"]);
+  const res = await getExecOutput("corepack", ["yarn", "--version"], {
+    silent: true,
+  });
   return res.stdout.trim();
 }
 


### PR DESCRIPTION
This pull request resolves #140 by modifying the `yarn.version` function to execute command silently.