### PR TITLE
Parse and Format Yarn Install Output

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79629,7 +79629,7 @@ async function yarnInstall() {
     env["FORCE_COLOR"] = "true";
     // Prevent no lock file causing errors.
     env["CI"] = "";
-    await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.exec)("corepack", ["yarn", "install"], { env });
+    await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.exec)("corepack", ["yarn", "install", "--json"], { env });
 }
 async function getYarnVersion() {
     const res = await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.getExecOutput)("corepack", ["yarn", "--version"], {

--- a/dist/index.js
+++ b/dist/index.js
@@ -79610,6 +79610,7 @@ __webpack_async_result__();
 /* harmony export */   "Wd": () => (/* binding */ enableYarn),
 /* harmony export */   "io": () => (/* binding */ getYarnConfig)
 /* harmony export */ });
+/* unused harmony export printYarnInstallOutput */
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(4278);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(8434);
@@ -79625,6 +79626,19 @@ async function getYarnConfig(name) {
     });
     return JSON.parse(res.stdout).effective;
 }
+function printYarnInstallOutput(output) {
+    switch (output.type) {
+        case "info":
+            _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`${output.displayName}: ${output.indent}${output.data}`);
+            break;
+        case "warning":
+            _actions_core__WEBPACK_IMPORTED_MODULE_0__.warning(`${output.data} (${output.displayName})`);
+            break;
+        case "error":
+            _actions_core__WEBPACK_IMPORTED_MODULE_0__.error(`${output.data} (${output.displayName})`);
+            break;
+    }
+}
 async function yarnInstall() {
     const env = process.env;
     // Prevent `yarn install` from outputting group log messages.
@@ -79637,18 +79651,8 @@ async function yarnInstall() {
         silent: true,
         listeners: {
             stdline: (data) => {
-                const info = JSON.parse(data);
-                switch (info.type) {
-                    case "info":
-                        _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`${info.displayName}: ${info.indent}${info.data}`);
-                        break;
-                    case "warning":
-                        _actions_core__WEBPACK_IMPORTED_MODULE_0__.warning(`${info.data} (${info.displayName})`);
-                        break;
-                    case "error":
-                        _actions_core__WEBPACK_IMPORTED_MODULE_0__.error(`${info.data} (${info.displayName})`);
-                        break;
-                }
+                const output = JSON.parse(data);
+                printYarnInstallOutput(output);
             },
         },
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -79610,14 +79610,17 @@ __webpack_async_result__();
 /* harmony export */   "Wd": () => (/* binding */ enableYarn),
 /* harmony export */   "io": () => (/* binding */ getYarnConfig)
 /* harmony export */ });
-/* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(8434);
-/* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_exec__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(4278);
+/* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(8434);
+/* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__nccwpck_require__.n(_actions_exec__WEBPACK_IMPORTED_MODULE_1__);
+
 
 async function enableYarn() {
-    await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.exec)("corepack", ["enable", "yarn"]);
+    await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_1__.exec)("corepack", ["enable", "yarn"]);
 }
 async function getYarnConfig(name) {
-    const res = await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.getExecOutput)("corepack", ["yarn", "config", name, "--json"], {
+    const res = await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_1__.getExecOutput)("corepack", ["yarn", "config", name, "--json"], {
         silent: true,
     });
     return JSON.parse(res.stdout).effective;
@@ -79629,10 +79632,29 @@ async function yarnInstall() {
     env["FORCE_COLOR"] = "true";
     // Prevent no lock file causing errors.
     env["CI"] = "";
-    await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.exec)("corepack", ["yarn", "install", "--json"], { env });
+    await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_1__.exec)("corepack", ["yarn", "install", "--json"], {
+        env,
+        silent: true,
+        listeners: {
+            stdline: (data) => {
+                const info = JSON.parse(data);
+                switch (info.type) {
+                    case "info":
+                        _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`${info.displayName}: ${info.indent}${info.data}`);
+                        break;
+                    case "warning":
+                        _actions_core__WEBPACK_IMPORTED_MODULE_0__.warning(`${info.data} (${info.displayName})`);
+                        break;
+                    case "error":
+                        _actions_core__WEBPACK_IMPORTED_MODULE_0__.error(`${info.data} (${info.displayName})`);
+                        break;
+                }
+            },
+        },
+    });
 }
 async function getYarnVersion() {
-    const res = await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_0__.getExecOutput)("corepack", ["yarn", "--version"], {
+    const res = await (0,_actions_exec__WEBPACK_IMPORTED_MODULE_1__.getExecOutput)("corepack", ["yarn", "--version"], {
         silent: true,
     });
     return res.stdout.trim();

--- a/src/yarn.test.ts
+++ b/src/yarn.test.ts
@@ -53,14 +53,18 @@ it("should install package using Yarn", async () => {
   await yarnInstall();
 
   expect(mock.exec).toHaveBeenCalledTimes(1);
-  expect(mock.exec).toHaveBeenCalledWith("corepack", ["yarn", "install"], {
-    env: {
-      ...process.env,
-      GITHUB_ACTIONS: "",
-      FORCE_COLOR: "true",
-      CI: "",
+  expect(mock.exec).toHaveBeenCalledWith(
+    "corepack",
+    ["yarn", "install", "--json"],
+    {
+      env: {
+        ...process.env,
+        GITHUB_ACTIONS: "",
+        FORCE_COLOR: "true",
+        CI: "",
+      },
     },
-  });
+  );
 });
 
 it("should get Yarn version", async () => {

--- a/src/yarn.test.ts
+++ b/src/yarn.test.ts
@@ -120,18 +120,16 @@ it("should install package using Yarn", async () => {
   await yarnInstall();
 
   expect(mock.exec).toHaveBeenCalledTimes(1);
-  expect(mock.exec).toHaveBeenCalledWith(
-    "corepack",
-    ["yarn", "install", "--json"],
-    {
-      env: {
-        ...process.env,
-        GITHUB_ACTIONS: "",
-        FORCE_COLOR: "true",
-        CI: "",
-      },
-    },
-  );
+  expect(mock.exec.mock.calls[0]).toHaveLength(3);
+  expect(mock.exec.mock.calls[0][0]).toBe("corepack");
+  expect(mock.exec.mock.calls[0][1]).toEqual(["yarn", "install", "--json"]);
+  expect(mock.exec.mock.calls[0][2]).toHaveProperty("env");
+  expect(mock.exec.mock.calls[0][2].env).toEqual({
+    ...process.env,
+    GITHUB_ACTIONS: "",
+    FORCE_COLOR: "true",
+    CI: "",
+  });
 });
 
 it("should get Yarn version", async () => {

--- a/src/yarn.test.ts
+++ b/src/yarn.test.ts
@@ -117,6 +117,13 @@ describe("print Yarn install package output", () => {
 it("should install package using Yarn", async () => {
   const { yarnInstall } = await import("./yarn.js");
 
+  mock.exec.mockImplementation(async (commandLine, args, options) => {
+    options?.listeners?.stdline(
+      `{"type":"info","name":null,"displayName":"YN0000","indent":"","data":"└ Completed"}`,
+    );
+    return 0;
+  });
+
   await yarnInstall();
 
   expect(mock.exec).toHaveBeenCalledTimes(1);
@@ -130,6 +137,9 @@ it("should install package using Yarn", async () => {
     FORCE_COLOR: "true",
     CI: "",
   });
+
+  expect(mock.core.info).toHaveBeenCalledTimes(1);
+  expect(mock.core.info).toHaveBeenCalledWith("YN0000: └ Completed");
 });
 
 it("should get Yarn version", async () => {

--- a/src/yarn.test.ts
+++ b/src/yarn.test.ts
@@ -1,10 +1,18 @@
+import * as core from "@actions/core";
 import { exec, getExecOutput } from "@actions/exec";
 import { jest } from "@jest/globals";
 
 const mock = {
+  core: {
+    error: jest.fn<typeof core.error>(),
+    info: jest.fn<typeof core.info>(),
+    warning: jest.fn<typeof core.warning>(),
+  },
   exec: jest.fn<typeof exec>(),
   getExecOutput: jest.fn<typeof getExecOutput>(),
 };
+
+jest.unstable_mockModule("@actions/core", () => mock.core);
 
 jest.unstable_mockModule("@actions/exec", () => ({
   exec: mock.exec,
@@ -45,6 +53,65 @@ it("should get Yarn config", async () => {
   );
 
   expect(value).toEqual("/.yarn/berry");
+});
+
+describe("print Yarn install package output", () => {
+  it("should print info output", async () => {
+    const { printYarnInstallOutput } = await import("./yarn.js");
+
+    printYarnInstallOutput({
+      type: "info",
+      displayName: "YN0000",
+      indent: ". ",
+      data: "\u001b[1mYarn 4.1.0\u001b[22m",
+    });
+
+    expect(mock.core.info).toHaveBeenCalledTimes(1);
+    expect(mock.core.info).toHaveBeenCalledWith(
+      "YN0000: . \u001b[1mYarn 4.1.0\u001b[22m",
+    );
+
+    expect(mock.core.warning).toHaveBeenCalledTimes(0);
+    expect(mock.core.error).toHaveBeenCalledTimes(0);
+  });
+
+  it("should print warning output", async () => {
+    const { printYarnInstallOutput } = await import("./yarn.js");
+
+    printYarnInstallOutput({
+      type: "warning",
+      displayName: "YN0000",
+      indent: "│ ",
+      data: "ESM support for PnP uses the experimental loader API and is therefore experimental",
+    });
+
+    expect(mock.core.warning).toHaveBeenCalledTimes(1);
+    expect(mock.core.warning).toHaveBeenCalledWith(
+      "ESM support for PnP uses the experimental loader API and is therefore experimental (YN0000)",
+    );
+
+    expect(mock.core.info).toHaveBeenCalledTimes(0);
+    expect(mock.core.error).toHaveBeenCalledTimes(0);
+  });
+
+  it("should print error output", async () => {
+    const { printYarnInstallOutput } = await import("./yarn.js");
+
+    printYarnInstallOutput({
+      type: "error",
+      displayName: "YN0028",
+      indent: ". ",
+      data: "The lockfile would have been created by this install, which is explicitly forbidden.",
+    });
+
+    expect(mock.core.error).toHaveBeenCalledTimes(1);
+    expect(mock.core.error).toHaveBeenCalledWith(
+      "The lockfile would have been created by this install, which is explicitly forbidden. (YN0028)",
+    );
+
+    expect(mock.core.info).toHaveBeenCalledTimes(0);
+    expect(mock.core.warning).toHaveBeenCalledTimes(0);
+  });
 });
 
 it("should install package using Yarn", async () => {

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -16,6 +16,13 @@ export async function getYarnConfig(name: string): Promise<string> {
   return JSON.parse(res.stdout).effective;
 }
 
+export interface YarnInstallOutput {
+  type: "info" | "warning" | "error";
+  displayName: string;
+  indent: string;
+  data: string;
+}
+
 export async function yarnInstall(): Promise<void> {
   const env = process.env as { [key: string]: string };
 
@@ -31,7 +38,7 @@ export async function yarnInstall(): Promise<void> {
     silent: true,
     listeners: {
       stdline: (data) => {
-        const info = JSON.parse(data);
+        const info = JSON.parse(data) as YarnInstallOutput;
         switch (info.type) {
           case "info":
             core.info(`${info.displayName}: ${info.indent}${info.data}`);

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -25,7 +25,7 @@ export async function yarnInstall(): Promise<void> {
   // Prevent no lock file causing errors.
   env["CI"] = "";
 
-  await exec("corepack", ["yarn", "install"], { env });
+  await exec("corepack", ["yarn", "install", "--json"], { env });
 }
 
 export async function getYarnVersion() {

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -23,6 +23,20 @@ export interface YarnInstallOutput {
   data: string;
 }
 
+export function printYarnInstallOutput(output: YarnInstallOutput): void {
+  switch (output.type) {
+    case "info":
+      core.info(`${output.displayName}: ${output.indent}${output.data}`);
+      break;
+    case "warning":
+      core.warning(`${output.data} (${output.displayName})`);
+      break;
+    case "error":
+      core.error(`${output.data} (${output.displayName})`);
+      break;
+  }
+}
+
 export async function yarnInstall(): Promise<void> {
   const env = process.env as { [key: string]: string };
 
@@ -38,18 +52,8 @@ export async function yarnInstall(): Promise<void> {
     silent: true,
     listeners: {
       stdline: (data) => {
-        const info = JSON.parse(data) as YarnInstallOutput;
-        switch (info.type) {
-          case "info":
-            core.info(`${info.displayName}: ${info.indent}${info.data}`);
-            break;
-          case "warning":
-            core.warning(`${info.data} (${info.displayName})`);
-            break;
-          case "error":
-            core.error(`${info.data} (${info.displayName})`);
-            break;
-        }
+        const output = JSON.parse(data) as YarnInstallOutput;
+        printYarnInstallOutput(output);
       },
     },
   });


### PR DESCRIPTION
This pull request resolves #150 by introducing the following changes:
- Modifies the `yarnInstall` function to run silently while outputting logs in JSON format, which can later be parsed and formatted in GitHub Actions log style.
- Introduces the `YarnInstallOutput` interface and the `printYarnInstallOutput` function to assist in parsing and formatting the Yarn install output.
- Adds and fixes testing accordingly.