### PR TITLE
Remove Hack Preventing Grouped Output During Yarn Install

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79632,12 +79632,7 @@ function printYarnInstallOutput(output) {
     }
 }
 async function yarnInstall() {
-    const env = process.env;
-    // Prevent `yarn install` from outputting group log messages.
-    env["GITHUB_ACTIONS"] = "";
-    env["FORCE_COLOR"] = "true";
     await (0,exec.exec)("corepack", ["yarn", "install", "--json"], {
-        env,
         silent: true,
         listeners: {
             stdline: (data) => {

--- a/src/yarn/install.test.ts
+++ b/src/yarn/install.test.ts
@@ -96,12 +96,6 @@ it("should install package using Yarn", async () => {
   expect(mock.exec.mock.calls[0]).toHaveLength(3);
   expect(mock.exec.mock.calls[0][0]).toBe("corepack");
   expect(mock.exec.mock.calls[0][1]).toEqual(["yarn", "install", "--json"]);
-  expect(mock.exec.mock.calls[0][2]).toHaveProperty("env");
-  expect(mock.exec.mock.calls[0][2].env).toEqual({
-    ...process.env,
-    GITHUB_ACTIONS: "",
-    FORCE_COLOR: "true",
-  });
 
   expect(mock.core.info).toHaveBeenCalledTimes(1);
   expect(mock.core.info).toHaveBeenCalledWith("YN0000: └ Completed");

--- a/src/yarn/install.ts
+++ b/src/yarn/install.ts
@@ -23,14 +23,7 @@ export function printYarnInstallOutput(output: YarnInstallOutput): void {
 }
 
 export async function yarnInstall(): Promise<void> {
-  const env = process.env as { [key: string]: string };
-
-  // Prevent `yarn install` from outputting group log messages.
-  env["GITHUB_ACTIONS"] = "";
-  env["FORCE_COLOR"] = "true";
-
   await exec("corepack", ["yarn", "install", "--json"], {
-    env,
     silent: true,
     listeners: {
       stdline: (data) => {


### PR DESCRIPTION
This pull request resolves #154 by removing the lines in the `yarnInstall` function that are responsible for preventing grouped output during Yarn installation.