### PR TITLE
Enable Yarn Silently

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79657,7 +79657,7 @@ async function yarnInstall() {
 
 
 async function enableYarn() {
-    await (0,exec.exec)("corepack", ["enable", "yarn"]);
+    await (0,exec.exec)("corepack", ["enable", "yarn"], { silent: true });
 }
 async function getYarnConfig(name) {
     const res = await (0,exec.getExecOutput)("corepack", ["yarn", "config", name, "--json"], {

--- a/dist/index.js
+++ b/dist/index.js
@@ -79579,9 +79579,8 @@ _cache_js__WEBPACK_IMPORTED_MODULE_2__ = (__webpack_async_dependencies__.then ? 
 
 
 async function main() {
-    await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Enabling Yarn", async () => {
-        await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .enableYarn */ .Wd)();
-    });
+    _actions_core__WEBPACK_IMPORTED_MODULE_1__.info("Enabling Yarn...");
+    await (0,_yarn_index_js__WEBPACK_IMPORTED_MODULE_3__/* .enableYarn */ .Wd)();
     const cacheKey = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Getting cache key", _cache_js__WEBPACK_IMPORTED_MODULE_2__/* .getCacheKey */ .a);
     const cachePaths = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Getting cache paths", _cache_js__WEBPACK_IMPORTED_MODULE_2__/* .getCachePaths */ .N);
     const cacheFound = await _actions_core__WEBPACK_IMPORTED_MODULE_1__.group("Restoring cache", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,9 +4,8 @@ import { getCacheKey, getCachePaths } from "./cache.js";
 import { enableYarn, yarnInstall } from "./yarn/index.js";
 
 export async function main(): Promise<void> {
-  await core.group("Enabling Yarn", async () => {
-    await enableYarn();
-  });
+  core.info("Enabling Yarn...");
+  await enableYarn();
 
   const cacheKey = await core.group("Getting cache key", getCacheKey);
   const cachePaths = await core.group("Getting cache paths", getCachePaths);

--- a/src/yarn/index.test.ts
+++ b/src/yarn/index.test.ts
@@ -21,7 +21,9 @@ it("should enable Yarn", async () => {
   await enableYarn();
 
   expect(mock.exec).toHaveBeenCalledTimes(1);
-  expect(mock.exec).toHaveBeenCalledWith("corepack", ["enable", "yarn"]);
+  expect(mock.exec).toHaveBeenCalledWith("corepack", ["enable", "yarn"], {
+    silent: true,
+  });
 });
 
 it("should get Yarn config", async () => {

--- a/src/yarn/index.ts
+++ b/src/yarn/index.ts
@@ -2,7 +2,7 @@ import { exec, getExecOutput } from "@actions/exec";
 export { yarnInstall } from "./install.js";
 
 export async function enableYarn(): Promise<void> {
-  await exec("corepack", ["enable", "yarn"]);
+  await exec("corepack", ["enable", "yarn"], { silent: true });
 }
 
 export async function getYarnConfig(name: string): Promise<string> {


### PR DESCRIPTION
This pull request resolves #164 by modifying the `yarnEnable` function to execute the command silently. It also modifies the enable Yarn step in the `main` function to log output without grouping.